### PR TITLE
Fix mention of "Debug" when it should be "Display" in impl part 1

### DIFF
--- a/content/blog/a_new_impl_trait_1.md
+++ b/content/blog/a_new_impl_trait_1.md
@@ -123,7 +123,7 @@ println!("{}", combine_abstract(1, 2));
 println!("{:?}", combine_abstract(1, 2));
 ```
 
-Now we have _abstracted_ our return type using `impl Trait`, and that opaque return type does not implement `Debug`. Note that we also had to bound `T::Output: Display` since our `impl Debug` requires that the value inside of it implements `Debug`. While we can still `Display` the return value of `combine_abstract`, we can no longer `Debug` it. That's the very literal difference when using `impl Trait`, but what does that actually mean for our code?
+Now we have _abstracted_ our return type using `impl Trait`, and that opaque return type does not implement `Debug`. Note that we also had to bound `T::Output: Display` since our `impl Display` requires that the value inside of it implements `Display`. While we can still `Display` the return value of `combine_abstract`, we can no longer `Debug` it. That's the very literal difference when using `impl Trait`, but what does that actually mean for our code?
 
 ## Should you abstract your types?
 

--- a/content/blog/a_new_impl_trait_2.md
+++ b/content/blog/a_new_impl_trait_2.md
@@ -103,7 +103,7 @@ Before we put these ideas together into a coherent proposal, I'd like to address
 
 In the [last post](@/blog/a_new_impl_trait_1.md), we looked at "Return position `impl Trait` in traits" (RPITIT) and "Type alias `impl Trait`" (TAIT). To be clear, I don't think either of these proposals are bad. I just think they miss the mark, and it's not their fault. Here's why:
 
-When we desugar return position `impl Trait`, it gets hidden in a wrapper type and that _type_ is abstract. In fact, that type is _an abstraction_ over the concrete type. I argue that we're missing that extra informaiton, and that is leading us down the path of type inference. Instead of declaring our type aliases and leveraging those for inference, we instead have to declare our alias and then be painfully specific everywhere that we use it:
+When we desugar return position `impl Trait`, it gets hidden in a wrapper type and that _type_ is abstract. In fact, that type is _an abstraction_ over the concrete type. I argue that we're missing that extra information, and that is leading us down the path of type inference. Instead of declaring our type aliases and leveraging those for inference, we instead have to declare our alias and then be painfully specific everywhere that we use it:
 
 ```rust
 #![feature(type_alias_impl_trait)]

--- a/content/blog/a_new_impl_trait_2.md
+++ b/content/blog/a_new_impl_trait_2.md
@@ -121,7 +121,7 @@ fn b() -> Handle {
 }
 ```
 
-If you thought that this would compile, I don't blame you! We should have all the information we need to deduce that `Integer` is an abstract pointer to an `i32`. However, that's not what we get:
+If you thought that this would compile, I don't blame you! We should have all the information we need to deduce that `Handle` is an abstract pointer to an `i32`. However, that's not what we get:
 
 ```
 error[E0282]: type annotations needed
@@ -131,7 +131,7 @@ error[E0282]: type annotations needed
    |     ^^^^ cannot infer type for type parameter `T` declared on the function `null`
 ```
 
-This is because we're inferring the type of `Integer`, and we don't want to accidentally infer the wrong type in a situation where we're _actually_ confused. Compare this to a concrete type alias:
+This is because we're inferring the type of `Handle`, and we don't want to accidentally infer the wrong type in a situation where we're _actually_ confused. Compare this to a concrete type alias:
 
 ```rust
 #![feature(type_alias_impl_trait)]

--- a/content/blog/a_new_impl_trait_4.md
+++ b/content/blog/a_new_impl_trait_4.md
@@ -45,7 +45,7 @@ If `foo`'s return type is inferred, then `bar` must either:
 
 A type alias doesn't change the situation here, as it would also either state `type Output = <foo as Fn(T)>::Output` or `type Output = _`.
 
-If we infer the return type of `bar` from its body, we end up long-range type inference and spooky action at a distance. This has the additional downside that it opens the door for inference to be used in places where it's not strictly necessary. This could lead to further confusion and, in my opinion, would render the feature more harm than good.
+If we infer the return type of `bar` from its body, we end up long-range type inference and spooky action at a distance. This has the additional downside that it opens the door for inference to be used in places where it's not strictly necessary. This could lead to further confusion and, in my opinion, would render the feature more harmful than helpful.
 
 If we refer to `foo` to name `bar`'s return type, we end up with `foo` only performing local inference which is arguably better. However, we suffer from the explicit function output signature, especially when we want to change the definition of `foo`. Modifying its arguments would require modifying the type signature of `bar` (or equivalently, the signature of the type alias) even when the return type has not changed. It makes maintenance more difficult at the same time as making discoverability more difficult.
 


### PR DESCRIPTION
This fixes a few typos and one grammar issue. The last commit is the grammar change and you may not want to include it.

Also, I'm only 95% sure that the first commit is right, but I _think_ it is.

As an aside, one thing I've done on my blog is link to GitHub on every page so that people can easily submit PRs for typos. See the bottom of https://blog.urth.org/2022/05/14/restoring-window-positions-in-gnome-after-switching-monitor-inputs/ for an example. This was a pretty small change to the Hugo template, but it did mean forking the theme I use.